### PR TITLE
Vuex clear auth missing bug

### DIFF
--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -23,7 +23,7 @@ const actions = {
   setLogoutTimer: ({ commit }, expirationTime) => {
       setTimeout(() => {
         commit('user/clearUser', {}, { root: true })
-        commit("clearAuth");
+        commit("clearToken");
       }, expirationTime * 1000);
     },
   register: async ({ commit, dispatch }, formData) => {

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -100,7 +100,7 @@ const actions = {
       type: 'success',
       text: 'You have been logged out.'
     }, { root: true })
-    router.replace("/login");
+    router.replace("/");
   },  
 }
 


### PR DESCRIPTION
The setTimeoutTimer action I was using to automatically log a user out after two hours was committing the wrong mutation (clearAuth != clearToken). Should be working now, but need to write tests.