### PR TITLE
Update last updated date of the site in humans.txt

### DIFF
--- a/src/assets/humans.txt
+++ b/src/assets/humans.txt
@@ -13,7 +13,7 @@ VSFS 2019-2020 Interns:
 
 /* SITE */
 
-Last update: 2019/04/02 
+Last update: 2019/09/04
 
 Standards: HTML5, CSS3, ES6
 


### PR DESCRIPTION
Related to issue #6 

Update to YYYY/MM/DD format as specified in humanstxt.org based on time of last commit (before this one)

It's interesting to note that the it seems like the format is slightly different from http://humanstxt.org/Standard.html in that there are blank lines between fields, and going to the html5 boilerplate that is recommended on humanstxt.org itself, it seems they are rolling their own version.

Example: https://github.com/h5bp/html5-boilerplate/blob/master/dist/humans.txt

_We're only human after all_